### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ module XOR(output out1,  input in1, in2);
   wire w1, w2, w3, w4;
   not (w1, in1);
   not (w2, in2);
-  not (w3, in1, w2);
-  not (w4, in2, w1);
+  and (w3, in1, w2);
+  and (w4, in2, w1);
   or (out1, w3, w4);
 endmodule
 ```


### PR DESCRIPTION
Those not should be and instead. Is there any reason why you prefer to use not instead of and ? Also not should be an unary operation, not a binary one. 