### PR TITLE
Removes redirect from about link if logged out

### DIFF
--- a/src/main/webapp/js/main.js
+++ b/src/main/webapp/js/main.js
@@ -21,12 +21,6 @@ $('#options_link').on('click', function() {
         return false; // prevents current page from reloading so that the new page can be loaded
     }
 });
-$('#about_link').on('click', function() {
-    if(isRegistered()) {
-        window.location.replace('about.html');
-        return false; // prevents current page from reloading so that the new page can be loaded
-    }
-});
 
 
 //force the X close button to show up in dialog box.


### PR DESCRIPTION
This let's you view the about page when you click the link in the navbar even if you're logged out. This let's you learn more about the project before deciding to sign up. Also it addresses the issue rkrishnasanka raised.