### PR TITLE
Fixed bug preventing swaps in simulated annealing algorithm

### DIFF
--- a/src/main/java/org/cellocad/MIT/dnacompiler/BuildCircuitsSimAnnealing.java
+++ b/src/main/java/org/cellocad/MIT/dnacompiler/BuildCircuitsSimAnnealing.java
@@ -313,7 +313,7 @@ public class BuildCircuitsSimAnnealing extends BuildCircuits {
             }
 
             //allow non-duplicate groups
-            if (!currentlyAssignedGroup(lc, g.Group)) {
+            if (!currentlyAssignedGroup(lc, g.Group) || isNextGateCurrentlyUsed(lc, g)) {
                 allowed_B_gates.put(g.Name, g);
             }
 


### PR DESCRIPTION
There was a bug in the simulated annealing that prevented the algorithm from performing 'swaps' between gates in a circuit (only 'substitutions' were ever performed). 