### PR TITLE
Updates to Makefile to fix matplotlib failure and non-interactive installation 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ EXPOSE 8080:8080
 # Install dependencies
 RUN apt-get update
 RUN apt-get install -y tzdata
-RUN apt-get install -y git gcc-multilib  openjdk-8-jdk openjdk-8-jre-headless maven \
-gnuplot ghostscript graphviz imagemagick python-matplotlib 
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y git gcc-multilib  openjdk-8-jdk openjdk-8-jre-headless maven \
+gnuplot ghostscript graphviz imagemagick python3-matplotlib 
 
 
 # Copy the local (outside Docker) source into the working directory,


### PR DESCRIPTION
Overview:

Two small changes:

1) Currently, the `python-matplotlib` endpoint no longer exists and will cause the image build to fail. This will resolve issue #50  

2) Removed user intervention dependence during one of the installation stages. This allows builds to be completed autonomously which is something required for current dev-ops buildout.

Testing:
The Dockerfile now resolves on Ubuntu 18.04 and creates a valid docker container.
